### PR TITLE
Add Key.params

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,9 @@ export type Key = {
   // Filename and line number the extracted translation key comes from
   sourceFilename: string;
   sourceLine: number;
+
+  // Parameter names passed in
+  params: Set<string>;
 };
 
 function parseKey(namespace: string, prefix: string | null, key: string) {
@@ -126,8 +129,9 @@ function visitCallExpression(
     }
   }
 
-  // Extract the default namespace and key prefix from the options in the last
-  // function argument
+  // Extract parameters, default namespace and key prefix from the options in
+  // the last function argument
+  let params = new Set<string>();
   if (optionsNode && ts.isObjectLiteralExpression(optionsNode)) {
     const optionsType = checker.getTypeAtLocation(optionsNode);
     const nsSymbol = optionsType.symbol.members?.get(ts.escapeLeadingUnderscores('ns'));
@@ -154,6 +158,11 @@ function visitCallExpression(
     ) {
       prefix = keyPrefixSymbol.valueDeclaration.initializer.text;
     }
+
+    if (optionsType.symbol.members) {
+      const identifiers = [...optionsType.symbol.members.keys()];
+      params = new Set(identifiers.map(ts.unescapeLeadingUnderscores));
+    }
   }
 
   const pos = file.getLineAndCharacterOfPosition(node.pos);
@@ -162,6 +171,7 @@ function visitCallExpression(
       ...parseKey(defaultNamespace, prefix, key),
       sourceFilename: file.fileName,
       sourceLine: pos.line + 1,
+      params,
     };
     extractedKeys.set(keyToString(keyMetadata), keyMetadata);
   }

--- a/test/basic/index.ts
+++ b/test/basic/index.ts
@@ -1,6 +1,7 @@
 import { t, getFixedT } from 'i18next';
 
 t('simple');
+t('withParams', { foo: 42, bar: 'asdf' })
 t('withNoopOptions', { defaultValue: 'asdf' });
 t('withNsOptions', { ns: 'foo' });
 t('withDefaultValue', 'asdf');

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,21 +4,22 @@ import { extractKeys } from '../index.ts';
 
 const expected = [
   { namespace: 'translation', key: 'simple' },
-  { namespace: 'translation', key: 'withNoopOptions' },
-  { namespace: 'foo', key: 'withNsOptions' },
+  { namespace: 'translation', key: 'withParams', params: new Set(['foo', 'bar']) },
+  { namespace: 'translation', key: 'withNoopOptions', params: new Set(['defaultValue']) },
+  { namespace: 'foo', key: 'withNsOptions', params: new Set(['ns']) },
   { namespace: 'translation', key: 'withDefaultValue' },
-  { namespace: 'translation', key: 'withDefaultValueAndNoopOptions' },
-  { namespace: 'foo', key: 'withDefaultValueAndNsOptions' },
+  { namespace: 'translation', key: 'withDefaultValueAndNoopOptions', params: new Set(['count']) },
+  { namespace: 'foo', key: 'withDefaultValueAndNsOptions', params: new Set(['ns']) },
   { namespace: 'foo', key: 'overrideNs' },
   { namespace: 'translation', key: 'templateWithoutSubstitution' },
 
   { namespace: 'custom', key: 'bar.simple' },
-  { namespace: 'customFoo', key: 'bar.withNsOptions' },
+  { namespace: 'customFoo', key: 'bar.withNsOptions', params: new Set(['ns']) },
   { namespace: 'customFoo', key: 'overrideNs' },
-  { namespace: 'customFoo', key: 'baz.withNsAndKeyPrefixOptions' },
+  { namespace: 'customFoo', key: 'baz.withNsAndKeyPrefixOptions', params: new Set(['keyPrefix', 'ns']) },
 
   { namespace: 'multipleNs', key: 'simple' },
-  { namespace: 'multipleNsFoo', key: 'withNsOptions' },
+  { namespace: 'multipleNsFoo', key: 'withNsOptions', params: new Set(['ns']) },
   { namespace: 'multipleNsFoo', key: 'overrideNs' },
 
   { namespace: 'translation', key: 'union.bar' },
@@ -39,6 +40,10 @@ const expected = [
 
 const keys = extractKeys({
   tsconfigPath: new URL(import.meta.resolve('./basic')),
-}).map(({ namespace, key }) => ({ namespace, key }));
+}).map(({ namespace, key, params }) => ({
+  namespace,
+  key,
+  ...(params.size > 0 && { params }),
+}));
 
 assert.deepStrictEqual(keys, expected);


### PR DESCRIPTION
- [ ] Do we want to expose the type of each param?
- [ ] Do we want to strip known i18next options?
- [ ] Is "variables" a better name?

Closes: https://github.com/emersion/i18next-typescript-parser/issues/4