### PR TITLE
Add Key.hasDefaultValue

### DIFF
--- a/test/basic/index.ts
+++ b/test/basic/index.ts
@@ -1,7 +1,7 @@
 import { t, getFixedT } from 'i18next';
 
 t('simple');
-t('withNoopOptions', { defaultValue: 'asdf' });
+t('withDefaultValueOptions', { defaultValue: 'asdf' });
 t('withNsOptions', { ns: 'foo' });
 t('withDefaultValue', 'asdf');
 t('withDefaultValueAndNoopOptions', 'asdf', { count: 42 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -5,11 +5,11 @@ import { extractKeys } from '../index.ts';
 
 const expected = [
   { namespace: 'translation', key: 'simple' },
-  { namespace: 'translation', key: 'withNoopOptions' },
+  { namespace: 'translation', key: 'withDefaultValueOptions', hasDefaultValue: true },
   { namespace: 'foo', key: 'withNsOptions' },
-  { namespace: 'translation', key: 'withDefaultValue' },
-  { namespace: 'translation', key: 'withDefaultValueAndNoopOptions' },
-  { namespace: 'foo', key: 'withDefaultValueAndNsOptions' },
+  { namespace: 'translation', key: 'withDefaultValue', hasDefaultValue: true },
+  { namespace: 'translation', key: 'withDefaultValueAndNoopOptions', hasDefaultValue: true },
+  { namespace: 'foo', key: 'withDefaultValueAndNsOptions', hasDefaultValue: true },
   { namespace: 'foo', key: 'overrideNs' },
   { namespace: 'translation', key: 'templateWithoutSubstitution' },
 
@@ -39,6 +39,10 @@ const expected = [
 ];
 
 process.chdir('test/basic');
-const keys = extractKeys().map(({ namespace, key }) => ({ namespace, key }));
+const keys = extractKeys().map(({ namespace, key, hasDefaultValue }) => ({
+  namespace,
+  key,
+  ...(hasDefaultValue && { hasDefaultValue }),
+}));
 
 assert.deepStrictEqual(keys, expected);


### PR DESCRIPTION
If a default value is provided, the caller is expecting the lookup to maybe fail. As a result, a linter may want to relax unknown keys for these calls.

TODO: doesn't handle cases such as:

```ts
t('foo', t('bar'))
```