### PR TITLE
Add support for templates containing only string literals

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -113,16 +113,18 @@ function visitCallExpression(
     keys = [keyNode.text];
   } else {
     const keyType = checker.getTypeAtLocation(keyNode);
-    if (!keyType.isUnion()) {
-      return;
-    }
-
-    keys = [];
-    for (const t of keyType.types) {
-      if (!t.isStringLiteral()) {
-        return;
+    if (keyType.isStringLiteral()) {
+      keys = [keyType.value];
+    } else if (keyType.isUnion()) {
+      keys = [];
+      for (const t of keyType.types) {
+        if (!t.isStringLiteral()) {
+          return;
+        }
+        keys.push(t.value);
       }
-      keys.push(t.value);
+    } else {
+      return;
     }
   }
 

--- a/test/basic/index.ts
+++ b/test/basic/index.ts
@@ -8,6 +8,8 @@ t('withDefaultValueAndNoopOptions', 'asdf', { count: 42 });
 t('withDefaultValueAndNsOptions', 'asdf', { ns: 'foo' });
 t('foo:overrideNs');
 t(`templateWithoutSubstitution`);
+const stringLiteral = 'Substitution' as const;
+t(`templateWithTrivial${stringLiteral}`);
 
 const customT = getFixedT(null, 'custom', 'bar');
 customT('simple');

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,6 +11,7 @@ const expected = [
   { namespace: 'foo', key: 'withDefaultValueAndNsOptions' },
   { namespace: 'foo', key: 'overrideNs' },
   { namespace: 'translation', key: 'templateWithoutSubstitution' },
+  { namespace: 'translation', key: 'templateWithTrivialSubstitution' },
 
   { namespace: 'custom', key: 'bar.simple' },
   { namespace: 'customFoo', key: 'bar.withNsOptions' },


### PR DESCRIPTION
Trivial templates such as `` `foo${"bar"}` `` would make the parser choke because they would pass neither ts.isStringLiteral(keyNode) (not being literals at the AST level) nor keyType.isUnion() (only a single choice is possible). Add a new case to handle these.

We could get rid of the AST-level checks if we wanted to, at the cost of more type-checking work.

Add a test for this case to avoid regressions.